### PR TITLE
Updated elgohr/Github-Release-Action to a supported version (v4)

### DIFF
--- a/.github/workflows/compilar.yml
+++ b/.github/workflows/compilar.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Ejecutamos las pruebas
         run: dotnet test
       - name: Publicar un release
-        uses: elgohr/Github-Release-Action@master
+        uses: elgohr/Github-Release-Action@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
elgohr/Github-Release-Action@master is not supported anymore